### PR TITLE
Prevent unneccesary objecturl creation

### DIFF
--- a/src/browser/getCreateFFmpegCore.js
+++ b/src/browser/getCreateFFmpegCore.js
@@ -9,33 +9,37 @@ const {
  * Fetch data from remote URL and convert to blob URL
  * to avoid CORS issue
  */
-const toBlobURL = async (url, mimeType) => {
-  log('info', `fetch ${url}`);
-  const buf = await (await fetch(url)).arrayBuffer();
-  log('info', `${url} file size = ${buf.byteLength} bytes`);
-  const blob = new Blob([buf], { type: mimeType });
-  const blobURL = URL.createObjectURL(blob);
-  log('info', `${url} blob URL = ${blobURL}`);
-  return blobURL;
-};
+// const toBlobURL = async (url, mimeType) => {
+//   log('info', `fetch ${url}`);
+//   const buf = await (await fetch(url)).arrayBuffer();
+//   log('info', `${url} file size = ${buf.byteLength} bytes`);
+//   const blob = new Blob([buf], { type: mimeType });
+//   const blobURL = URL.createObjectURL(blob);
+//   log('info', `${url} blob URL = ${blobURL}`);
+//   return blobURL;
+// };
 
 module.exports = async ({ corePath: _corePath }) => {
   if (typeof _corePath !== 'string') {
     throw Error('corePath should be a string!');
   }
+  // const corePath = await toBlobURL(
+  //   coreRemotePath,
+  //   'application/javascript',
+  // );
+  // const wasmPath = await toBlobURL(
+  //   coreRemotePath.replace('ffmpeg-core.js', 'ffmpeg-core.wasm'),
+  //   'application/wasm',
+  // );
+  // const workerPath = await toBlobURL(
+  //   coreRemotePath.replace('ffmpeg-core.js', 'ffmpeg-core.worker.js'),
+  //   'application/javascript',
+  // );
   const coreRemotePath = resolveURL(_corePath);
-  const corePath = await toBlobURL(
-    coreRemotePath,
-    'application/javascript',
-  );
-  const wasmPath = await toBlobURL(
-    coreRemotePath.replace('ffmpeg-core.js', 'ffmpeg-core.wasm'),
-    'application/wasm',
-  );
-  const workerPath = await toBlobURL(
-    coreRemotePath.replace('ffmpeg-core.js', 'ffmpeg-core.worker.js'),
-    'application/javascript',
-  );
+  const corePath = coreRemotePath;
+  const wasmPath = coreRemotePath.replace('ffmpeg-core.js', 'ffmpeg-core.wasm');
+  const workerPath = coreRemotePath.replace('ffmpeg-core.js', 'ffmpeg-core.worker.js');
+
   if (typeof createFFmpegCore === 'undefined') {
     return new Promise((resolve) => {
       const script = document.createElement('script');


### PR DESCRIPTION
new object URLs are created if the FFmpeg is loaded again after an exit

for now, just disabled object URL creation as we as the core script are present locally and hence would not lead to cors error

will do an actual fix later
